### PR TITLE
Fix long paths FileNotFoundError on Windows:

### DIFF
--- a/folderstats/__init__.py
+++ b/folderstats/__init__.py
@@ -29,6 +29,10 @@ def _recursive_folderstats(folderpath, items=[], hash_name=None,
     foldersize, num_files = 0, 0
     current_idx = idx
 
+    if os.name == 'nt':
+        PREFIX = '\\\\?\\'
+        folderpath = PREFIX + folderpath if not(PREFIX in folderpath) else folderpath
+        
     for f in os.listdir(folderpath):
         if ignore_hidden and f.startswith('.'):
             continue


### PR DESCRIPTION
- added PREFIX = '\\\\?\\' to folder path on Windows
- solution credits see url
URL: https://learning-python.com/cgi/showcode.py?name=mergeall-products/unzipped/docetc/miscnotes/demo-3.0-long-windows-paths-fix.txt